### PR TITLE
Pymodbus downgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ WORKDIR /FloatToHex
 RUN python3 setup.py install \
     && pip3 install --no-cache-dir \
        pandas==1.5.3 \
-       pymodbus==3.1.0
-
+       'pymodbus>=2,<3'
 
 # Building the docker image with already compiled modules
 FROM base

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Source code: [GitHub](https://github.com/cybcon/modbus-client)
 
 # Supported tags and respective `Dockerfile` links
 
-* [`latest`, `1.0.7`](https://github.com/cybcon/modbus-client/blob/1.0.7/Dockerfile)
+* [`latest`, `1.0.8`](https://github.com/cybcon/modbus-client/blob/v1.0.8/Dockerfile)
 * [`1.0.6`](https://github.com/cybcon/modbus-client/blob/1.0.6/Dockerfile)
 * [`1.0.5`](https://github.com/cybcon/modbus-client/blob/1.0.5/Dockerfile)
 * [`1.0.4`](https://github.com/cybcon/modbus-client/blob/1.0.4/dockerfile)

--- a/app/modbus_client.py
+++ b/app/modbus_client.py
@@ -8,7 +8,7 @@ Last modified at: 2023-01-20
 *************************************************************************** """
 import sys
 import os
-from pymodbus.client import ModbusTcpClient as ModbusClient
+from pymodbus.client.sync import ModbusTcpClient as ModbusClient
 import logging
 import argparse
 import struct
@@ -16,7 +16,7 @@ import pandas as pd
 import FloatToHex
 from numpy import little_endian
 
-VERSION='1.0.7'
+VERSION='1.0.8'
 DEBUG=False
 """
 ###############################################################################


### PR DESCRIPTION
Fixing modbus-client by downgrade the pymodbus python library to old 2.x release